### PR TITLE
카카오 로그인, 회원가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	testImplementation 'org.junit.jupiter:junit-jupiter' 
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'mysql:mysql-connector-java:8.0.32'
     
 }

--- a/src/main/java/com/hasu/zzol/WebConfig.java
+++ b/src/main/java/com/hasu/zzol/WebConfig.java
@@ -1,0 +1,19 @@
+package com.hasu.zzol;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedHeaders("Authorization", "Content-Type")
+                .exposedHeaders("Custom-Header")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/hasu/zzol/auth/AuthController.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthController.java
@@ -15,11 +15,10 @@ public class AuthController {
     private final AuthService authService;
     @GetMapping("/sign-in/kakao")
     @ResponseBody
-    public ResponseEntity<KakaoTokenDto> kakaoLogin(HttpServletRequest request) {
+    public ResponseEntity<SignInResponseDto> kakaoLogin(HttpServletRequest request) {
         // 프론트에서 전달한 인가 코드로 카카오 accessToken 발급
         String code = request.getParameter("code");
         KakaoTokenDto kakaoToken= authService.getKakaoAccessToken(code);
-        authService.kakaoLogin(kakaoToken.getAccess_token());
-        return ResponseEntity.ok(kakaoToken);
+        return authService.kakaoLogin(kakaoToken.getAccess_token());
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthController.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthController.java
@@ -1,0 +1,20 @@
+package com.hasu.zzol.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+    @GetMapping("/sign-in/oauth2/kakao")
+    public void kakaoLogin(HttpServletRequest request) {
+        // 프론트에서 전달한 인가 코드로 카카오 accessToken 발급
+        String code = request.getParameter("code");
+        String kakaoAccessToken = authService.getKakaoAccessToken(code).getAccess_token();
+    }
+}

--- a/src/main/java/com/hasu/zzol/auth/AuthController.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthController.java
@@ -4,15 +4,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @Controller
 @RequestMapping("/auth")
 public class AuthController {
     private final AuthService authService;
+
     @GetMapping("/sign-in/kakao")
     @ResponseBody
     public ResponseEntity<SignInResponseDto> kakaoLogin(HttpServletRequest request) {
@@ -20,5 +19,12 @@ public class AuthController {
         String code = request.getParameter("code");
         KakaoTokenDto kakaoToken= authService.getKakaoAccessToken(code);
         return authService.kakaoLogin(kakaoToken.getAccess_token());
+    }
+
+    @PostMapping("/sign-up/kakao")
+    @ResponseBody
+    public ResponseEntity<SignUpResponseDto> kakaoSignUp(@RequestBody SignUpRequestDto requestDto) {
+        return ResponseEntity.ok(authService.kakaoSignUp(requestDto));
+
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthController.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthController.java
@@ -18,7 +18,8 @@ public class AuthController {
     public ResponseEntity<KakaoTokenDto> kakaoLogin(HttpServletRequest request) {
         // 프론트에서 전달한 인가 코드로 카카오 accessToken 발급
         String code = request.getParameter("code");
-        KakaoTokenDto kakaoToken = authService.getKakaoAccessToken(code);
+        KakaoTokenDto kakaoToken= authService.getKakaoAccessToken(code);
+        authService.kakaoLogin(kakaoToken.getAccess_token());
         return ResponseEntity.ok(kakaoToken);
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthController.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthController.java
@@ -2,19 +2,23 @@ package com.hasu.zzol.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @RequiredArgsConstructor
 @Controller
 @RequestMapping("/auth")
 public class AuthController {
     private final AuthService authService;
-    @GetMapping("/sign-in/oauth2/kakao")
-    public void kakaoLogin(HttpServletRequest request) {
+    @GetMapping("/sign-in/kakao")
+    @ResponseBody
+    public ResponseEntity<KakaoTokenDto> kakaoLogin(HttpServletRequest request) {
         // 프론트에서 전달한 인가 코드로 카카오 accessToken 발급
         String code = request.getParameter("code");
-        String kakaoAccessToken = authService.getKakaoAccessToken(code).getAccess_token();
+        KakaoTokenDto kakaoToken = authService.getKakaoAccessToken(code);
+        return ResponseEntity.ok(kakaoToken);
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -1,0 +1,77 @@
+package com.hasu.zzol.auth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hasu.zzol.member.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final Environment environment;
+
+    @Value("${kakao.rest-api-key}")
+    private String restApiKey;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Transactional
+    public KakaoTokenDto getKakaoAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        System.out.println(code);
+        System.out.println(restApiKey);
+        System.out.println(redirectUri);
+        System.out.println(clientSecret);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code"); //카카오 공식문서 기준 authorization_code 로 고정
+        params.add("client_id", restApiKey); // 카카오 Dev 앱 REST API 키
+        params.add("redirect_uri",redirectUri); // 카카오 Dev redirect uri
+        params.add("code", code); // 프론트에서 인가 코드 요청시 받은 인가 코드값
+        params.add("client_secret", clientSecret); // 카카오 Dev 카카오 로그인 Client Secret
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        // 카카오로부터 Access token 받아오기
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> accessTokenResponse = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        System.out.println(accessTokenResponse);
+
+
+        // JSON Parsing (-> KakaoTokenDto)
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        KakaoTokenDto kakaoTokenDto = null;
+        try {
+            kakaoTokenDto = objectMapper.readValue(accessTokenResponse.getBody(), KakaoTokenDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return kakaoTokenDto;
+    }
+}

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hasu.zzol.member.Member;
 import com.hasu.zzol.member.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -75,7 +78,8 @@ public class AuthService {
 
 
     @Transactional
-    public void kakaoLogin(String kakaoAccessToken) {
+    public ResponseEntity<SignInResponseDto> kakaoLogin(String kakaoAccessToken) {
+        // 카카오 액세스 토큰으로 카카오 계정 정보 조회
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + kakaoAccessToken);
         headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
@@ -96,9 +100,13 @@ public class AuthService {
             e.printStackTrace();
         }
 
-
-        System.out.println(kakaoAccountInfo.getId()); //카카오 회원 번호
-        System.out.println(kakaoAccountInfo.getKakao_account().getEmail()); // 카카오 대표 이메일
+        // 동일한 카카오 id를 가진 계정이 있는지 조회
+        SignInResponseDto signInResponse = new SignInResponseDto();
+        signInResponse.setKakaoId(kakaoAccountInfo.getId());
+        signInResponse.setKakaoAccount(kakaoAccountInfo.getKakao_account());
+        Optional<Member> om = memberRepository.findByKakaoId(kakaoAccountInfo.getId());
+        signInResponse.setRegistered(om.isPresent());
+        return ResponseEntity.ok(signInResponse);
 
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -35,11 +35,6 @@ public class AuthService {
 
     @Transactional
     public KakaoTokenDto getKakaoAccessToken(String code) {
-        System.out.println(code);
-        System.out.println(restApiKey);
-        System.out.println(redirectUri);
-        System.out.println(clientSecret);
-
         // 인가 코드로 카카오 액세스 토큰 요청
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -18,6 +18,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -105,8 +106,22 @@ public class AuthService {
         signInResponse.setKakaoId(kakaoAccountInfo.getId());
         signInResponse.setKakaoAccount(kakaoAccountInfo.getKakao_account());
         Optional<Member> om = memberRepository.findByKakaoId(kakaoAccountInfo.getId());
-        signInResponse.setRegistered(om.isPresent());
+        if (om.isPresent()) {
+            signInResponse.setRegistered(true);
+            signInResponse.setMember(om.get());
+        }
         return ResponseEntity.ok(signInResponse);
 
+    }
+
+    public SignUpResponseDto kakaoSignUp(SignUpRequestDto requestDto) {
+        if (memberRepository.findByKakaoId(requestDto.getKakaoId()).isPresent()) {
+            throw new IllegalArgumentException("이미 등록된 계정입니다.");
+        }
+
+        Member member = Member.builder().nickname(requestDto.getNickname()).kakaoId(requestDto.getKakaoId()).email(requestDto.getEmail()).birthDate(requestDto.getBirthDate()).memberState("정상").createDt(LocalDateTime.now()).build();
+        memberRepository.save(member);
+
+        return new SignUpResponseDto("회원가입 성공");
     }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -70,4 +70,35 @@ public class AuthService {
 
         return kakaoTokenDto;
     }
+
+
+
+
+    @Transactional
+    public void kakaoLogin(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + kakaoAccessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> kakaoAccountInfoRequest = new HttpEntity<>(headers);
+
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> kakaoAccountInfoResponse = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, kakaoAccountInfoRequest, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        KakaoAccountResponseDto kakaoAccountInfo = null;
+        try {
+            kakaoAccountInfo = objectMapper.readValue(kakaoAccountInfoResponse.getBody(), KakaoAccountResponseDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+
+        System.out.println(kakaoAccountInfo.getId()); //카카오 회원 번호
+        System.out.println(kakaoAccountInfo.getKakao_account().getEmail()); // 카카오 대표 이메일
+
+    }
 }

--- a/src/main/java/com/hasu/zzol/auth/AuthService.java
+++ b/src/main/java/com/hasu/zzol/auth/AuthService.java
@@ -8,7 +8,6 @@ import com.hasu.zzol.member.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -22,7 +21,6 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class AuthService {
     private final MemberRepository memberRepository;
-    private final Environment environment;
 
     @Value("${kakao.rest-api-key}")
     private String restApiKey;
@@ -33,13 +31,15 @@ public class AuthService {
 
     @Transactional
     public KakaoTokenDto getKakaoAccessToken(String code) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
         System.out.println(code);
         System.out.println(restApiKey);
         System.out.println(redirectUri);
         System.out.println(clientSecret);
+
+        // 인가 코드로 카카오 액세스 토큰 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code"); //카카오 공식문서 기준 authorization_code 로 고정
         params.add("client_id", restApiKey); // 카카오 Dev 앱 REST API 키
@@ -49,7 +49,6 @@ public class AuthService {
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
 
-        // 카카오로부터 Access token 받아오기
         RestTemplate rt = new RestTemplate();
         ResponseEntity<String> accessTokenResponse = rt.exchange(
                 "https://kauth.kakao.com/oauth/token",
@@ -57,9 +56,6 @@ public class AuthService {
                 kakaoTokenRequest,
                 String.class
         );
-
-        System.out.println(accessTokenResponse);
-
 
         // JSON Parsing (-> KakaoTokenDto)
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/hasu/zzol/auth/KakaoAccountDto.java
+++ b/src/main/java/com/hasu/zzol/auth/KakaoAccountDto.java
@@ -1,0 +1,11 @@
+package com.hasu.zzol.auth;
+
+import lombok.Data;
+
+@Data
+public class KakaoAccountDto {
+    String email;
+    Boolean has_email;
+    Boolean is_email_valid;
+    Boolean is_email_verified;
+}

--- a/src/main/java/com/hasu/zzol/auth/KakaoAccountResponseDto.java
+++ b/src/main/java/com/hasu/zzol/auth/KakaoAccountResponseDto.java
@@ -1,0 +1,9 @@
+package com.hasu.zzol.auth;
+
+import lombok.Data;
+
+@Data
+public class KakaoAccountResponseDto {
+    Long id;
+    KakaoAccountDto kakao_account;
+}

--- a/src/main/java/com/hasu/zzol/auth/KakaoTokenDto.java
+++ b/src/main/java/com/hasu/zzol/auth/KakaoTokenDto.java
@@ -4,11 +4,11 @@ import lombok.Data;
 
 @Data
 public class KakaoTokenDto {
+    private String token_type; // bearer 로 고정
     private String access_token;
-    private String token_type;
     private String refresh_token;
-    private String id_token;
-    private int expires_in;
-    private int refresh_token_expires_in;
-    private String scope;
+    private String id_token; // OpenId Connect 확장 기능에 이용
+    private int expires_in; // access_token, id_token 만료 시간(초)
+    private int refresh_token_expires_in; // refresh_token 만료 시간(초)
+    private String scope; // 사용자의 정보 조회 권한 범위
 }

--- a/src/main/java/com/hasu/zzol/auth/KakaoTokenDto.java
+++ b/src/main/java/com/hasu/zzol/auth/KakaoTokenDto.java
@@ -1,0 +1,14 @@
+package com.hasu.zzol.auth;
+
+import lombok.Data;
+
+@Data
+public class KakaoTokenDto {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private int refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/hasu/zzol/auth/SignInResponseDto.java
+++ b/src/main/java/com/hasu/zzol/auth/SignInResponseDto.java
@@ -1,0 +1,14 @@
+package com.hasu.zzol.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hasu.zzol.member.Member;
+import lombok.Data;
+
+@Data
+public class SignInResponseDto {
+    @JsonProperty("isRegistered")
+    private boolean isRegistered; // 회원가입을 한 회원인지 여부
+    private Long kakaoId;
+    private KakaoAccountDto kakaoAccount;
+    private Member member; // 회원가입을 한 회원일 때 채워서 줌
+}

--- a/src/main/java/com/hasu/zzol/auth/SignUpRequestDto.java
+++ b/src/main/java/com/hasu/zzol/auth/SignUpRequestDto.java
@@ -1,0 +1,16 @@
+package com.hasu.zzol.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class SignUpRequestDto {
+    private Long kakaoId;
+    private String nickname;
+    private String email;
+    private LocalDate birthDate;
+//    private String profileImgUrl;
+}

--- a/src/main/java/com/hasu/zzol/auth/SignUpResponseDto.java
+++ b/src/main/java/com/hasu/zzol/auth/SignUpResponseDto.java
@@ -1,0 +1,10 @@
+package com.hasu.zzol.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SignUpResponseDto {
+    private String message;
+}

--- a/src/main/java/com/hasu/zzol/member/Member.java
+++ b/src/main/java/com/hasu/zzol/member/Member.java
@@ -1,5 +1,6 @@
 package com.hasu.zzol.member;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
@@ -7,12 +8,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Member {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +31,7 @@ public class Member {
 	@Column(unique = true)
 	private String email;
 	
-	private LocalDateTime birthDate;
+	private LocalDate birthDate;
 	
 	private String profileImgUrl;
 	

--- a/src/main/java/com/hasu/zzol/member/Member.java
+++ b/src/main/java/com/hasu/zzol/member/Member.java
@@ -18,7 +18,7 @@ public class Member {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer memberNo;
 	
-	private String kakaoCredentailId;
+	private Long kakaoId;
 	
 	private String name;
 	

--- a/src/main/java/com/hasu/zzol/member/MemberRepository.java
+++ b/src/main/java/com/hasu/zzol/member/MemberRepository.java
@@ -2,6 +2,8 @@ package com.hasu.zzol.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+import java.util.Optional;
 
+public interface MemberRepository extends JpaRepository<Member, Integer> {
+    Optional<Member> findByKakaoId(Long kakaoId);
 }


### PR DESCRIPTION
- 토큰 발급 부분을 제외하고 회원 DB에 카카오 회원 번호 기준으로 해당 계정이 있는지 체크하고 카카오 계정, 서비스 회원 계정을 리턴하도록 처리했습니다.
- 회원가입 시에는 프론트에서 입력한 닉네임, 생일과 함께 로그인 때 받은 카카오 계정 정보를 서비스 서버에 전달해서 회원 DB 에 추가해줄 수 있도록 처리했습니다.
- 일단 cors 전체로 열어뒀습니닷